### PR TITLE
Reflect via indices outside boundaries

### DIFF
--- a/profiling/reflect.jl
+++ b/profiling/reflect.jl
@@ -1,7 +1,9 @@
 using CUDA
 using Flux
 using BenchmarkTools
+using Random
 
+using HighDimPDE
 if CUDA.functional()
     CUDA.allowscalar(false)
     _device = Flux.gpu
@@ -10,6 +12,21 @@ end
 # testing reflection on batchsize
 d = 100
 batch_size = 10000
+#
+for d in [2^i for i in 1:17]
+    Random.seed!(1)
+    X0 = fill(0.0f0,d)
+    X1 = X0 + randn(d)
+    println("\n\nd = $d\n")
+    if d <= 16384
+        args = copy.((X0, X1, -1, 1))
+        @time HighDimPDE._reflect(args...)
+        args = copy.((X0, X1, -1, 1))
+        @time HighDimPDE._reflect_GPU(args...)
+    end
+    args = copy.((X0, X1, -1, 1))
+    @time HighDimPDE._reflect_outs(args...)
+end
 y0 = CUDA.zeros(d,batch_size)
 y1 = CUDA.randn(size(y0)...)
 @btime _reflect_GPU2($y0,$y1,-1f0,1f0,_device)

--- a/src/reflect.jl
+++ b/src/reflect.jl
@@ -128,11 +128,12 @@ Checks if `b[n_idx]` (which corresponds to `out[rmin_idx]`) is within the specif
 The corresponding `out`-indices are removed before iterating the reflection.
 """
 function _discard_reflected_out_index!(out, out1, out2, rmin_idx)
+    offset = length(out1)
     if rmin_idx <= offset
         deleteat!(out1, rmin_idx)
         deleteat!(out, rmin_idx)
     else
-        deleteat!(out2, rmin_idx - length(out1))
+        deleteat!(out2, rmin_idx - offset)
         deleteat!(out, rmin_idx)
     end
 end

--- a/src/reflect.jl
+++ b/src/reflect.jl
@@ -88,3 +88,96 @@ function _reflect_GPU(a, b, s::Real, e::Real)
     end
     return b
 end
+
+function _out_indices(b, s::R, e::R) where {R<:Real}
+    out1 = findall(b .< s)
+    out2 = findall(b .> e)
+    out = vcat(out1, out2)
+    return out1, out2, out
+end
+
+
+"""
+    _rtemp_lower!(rtemp, a, b, s, out_lower)
+Update slice of `rtemp` corresponding to the lower boundary `s`.
+"""
+function _rtemp_lower!(rtemp, a, b, s, out_lower)
+    for i in 1:length(out_lower)
+        idx = out_lower[i]
+        rtemp[i] = @. (s - a[idx]) / (b[idx] - a[idx])
+    end
+end
+
+"""
+    _rtemp_lower!(rtemp, a, b, e, out_upper, offset)
+Update slice of `rtemp` corresponding to the upper boundary `e`.
+NOTE: An offset needs to be provided, corresponding to the number of dimensions where `b` is below the lower boundary.
+(SEE `rtemp_lower!`).
+"""
+function _rtemp_upper!(rtemp, a, b, e, out_upper, offset)
+    for i in 1:length(out_upper)
+        idx = out_upper[i]
+        rtemp[i + offset] = @. (e - a[idx]) / (b[idx] - a[idx])
+    end
+end
+
+
+"""
+    _discard_reflected_out_index!(out, out1, out2, rmin_idx)
+Checks if `b[n_idx]` (which corresponds to `out[rmin_idx]`) is within the specified boundary `[s, e]` after reflection along dimension `n_idx`.
+The corresponding `out`-indices are removed before iterating the reflection.
+"""
+function _discard_reflected_out_index!(out, out1, out2, rmin_idx)
+    if rmin_idx <= offset
+        deleteat!(out1, rmin_idx)
+        deleteat!(out, rmin_idx)
+    else
+        deleteat!(out2, rmin_idx - length(out1))
+        deleteat!(out, rmin_idx)
+    end
+end
+
+
+function _swap_boundary_outs!(out1, out2, n_idx, rmin_idx)
+    offset = length(out1)
+    # Should occur after reflecting OUT-OF-BOUNDS, where
+    # dimension `n_idx` is assigned to other `out`-vector
+    # for next reflection.
+    if rmin_idx <= offset
+        deleteat!(out1, rmin_idx)
+        push!(out2, n_idx)
+    else
+        deleteat!(out2, rmin_idx - offset)
+        push!(out1, n_idx)
+    end
+end
+
+function _reflect_outs(a, b, s::Real, e::Real)
+    all((a .>= s) .& (a .<= e)) ? nothing : error("a = $a not in hypercube")
+    size(a) == size(b) ? nothing : error("a not same dim as b")
+
+    # Initialize vectors of indices corresponding to dim of trajectories out of bounds
+    out1, out2, out = _out_indices(b, s, e)
+    rtemp = Vector{Float32}(undef, length(out))
+    while length(out) > 0
+        # TODO: Preallocate rtemp once, then remove elements with deleteat!(rtemp, rmin_idx)
+        _rtemp_lower!(rtemp, a, b, s, out1)
+        _rtemp_upper!(rtemp, a, b, e, out2, length(out1))
+        
+        rmin, rmin_idx = findmin(rtemp)
+        n_idx = out[rmin_idx]
+        @. a += (b - a) * rmin
+        b[n_idx] = -b[n_idx] + 2 * a[n_idx]
+        if s < b[n_idx] && b[n_idx] < e
+            # Within boundary after reflection, can reduce number of reflecting dimensions.
+            _discard_reflected_out_index!(out, out1, out2, rmin_idx)
+            deleteat!(rtemp, rmin_idx)
+        else
+            # Reflected outside boundary, need to move element between out1 and out2
+            # TODO: Reassign out-indices manually via _swap_boundary_outs!, for now, just recompute out-indices.
+            # _swap_boundary_outs!(out1, out2, n_idx, rmin_idx)
+            out1, out2, out = _out_indices(b, s, e)
+        end
+    end
+    return b
+end

--- a/test/reflect.jl
+++ b/test/reflect.jl
@@ -82,3 +82,16 @@ if CUDA.functional()
         end
     end
 end
+
+@testset "CPU index reflect methods" begin
+    d = 1000
+    X0 = fill(0.0f0,d)
+    X1 = X0 + randn(d)
+    @testset "test equivalence of index with cpu/gpu" begin
+        args = (X0, X1, -1, 1)
+        @test HighDimPDE._reflect(copy.(args)...) ≈ HighDimPDE._reflect_GPU(copy.(args)...)
+        @test HighDimPDE._reflect(copy.(args)...) ≈ HighDimPDE._reflect_outs(copy.(args)...)
+        @test HighDimPDE._reflect_GPU(copy.(args)...) ≈ HighDimPDE._reflect_outs(copy.(args)...)
+    end
+    
+end

--- a/test/reflect.jl
+++ b/test/reflect.jl
@@ -89,7 +89,6 @@ end
     X1 = X0 + randn(d)
     @testset "test equivalence of index with cpu/gpu" begin
         args = (X0, X1, -1, 1)
-        @test HighDimPDE._reflect(copy.(args)...) ≈ HighDimPDE._reflect_GPU(copy.(args)...)
         @test HighDimPDE._reflect(copy.(args)...) ≈ HighDimPDE._reflect_outs(copy.(args)...)
         @test HighDimPDE._reflect_GPU(copy.(args)...) ≈ HighDimPDE._reflect_outs(copy.(args)...)
     end


### PR DESCRIPTION
This PR adds `HighDimPDE_reflect_outs`, another implementation of `HighDimPDE._reflect`/`HighDimPDE._reflect_GPU`, which computes `out` (`out1` and `out2`) along with `rtemp`/`rmin` exclusively from indices of `b` where it "lies outside the boundary of `[s,e]^d`".

One should be able to reuse these indices in the while loop, but repeated reflections along a given dimension are slightly trickier to handle. These repeated reflections appear to be relatively uncommon, so a workaround would be to recompute `out1`, `out2` and `out` only for these cases in a given iteration.

`_swap_boundary_outs!` doesn't seem to work as expected, but the idea was to avoid recomputing `out1` and `out2` within the while loop.

I added some benchmarks, comparing the `reflect` methods for `d`-dimensional trajectories. Note that this is done with `batch_size=1`, see added code in `profiling/reflect.jl`.


<details>
<summary> Click to view benchmark results</summary>

```
d = 2
CPU       0.000003 seconds (7 allocations: 384 bytes)
GPU       0.000003 seconds (13 allocations: 768 bytes)
Index     0.000003 seconds (14 allocations: 864 bytes)

d = 4
CPU       0.000001 seconds (6 allocations: 384 bytes)
GPU       0.000002 seconds (13 allocations: 768 bytes)
Index     0.000002 seconds (14 allocations: 864 bytes)

d = 8
CPU       0.000004 seconds (21 allocations: 2.391 KiB)
GPU       0.000071 seconds (121 allocations: 6.172 KiB)
Index     0.000002 seconds (14 allocations: 928 bytes)

d = 16
CPU       0.000003 seconds (21 allocations: 3.328 KiB)
GPU       0.000024 seconds (121 allocations: 6.891 KiB)
Index     0.000002 seconds (14 allocations: 928 bytes)

d = 32
CPU       0.000004 seconds (56 allocations: 16.688 KiB)
GPU       0.000064 seconds (391 allocations: 27.625 KiB)
Index     0.000003 seconds (14 allocations: 1024 bytes)

d = 64
CPU       0.000024 seconds (154 allocations: 90.469 KiB)
GPU       0.000194 seconds (1.15 k allocations: 116.906 KiB)
Index     0.000004 seconds (14 allocations: 1.281 KiB)

d = 128
CPU       0.000060 seconds (336 allocations: 376.688 KiB)
GPU       0.000476 seconds (2.55 k allocations: 410.719 KiB)
Index     0.000009 seconds (14 allocations: 1.812 KiB)

d = 256
CPU       0.000252 seconds (582 allocations: 1.198 MiB)
GPU       0.001089 seconds (4.61 k allocations: 1.855 MiB)
Index     0.000018 seconds (17 allocations: 15.141 KiB)

d = 512
CPU       0.000682 seconds (1.19 k allocations: 4.774 MiB)
GPU       0.002394 seconds (9.48 k allocations: 5.790 MiB)
Index     0.000055 seconds (35 allocations: 40.375 KiB)

d = 1024
CPU       0.005550 seconds (2.28 k allocations: 18.064 MiB, 60.49% gc time)
GPU       0.005773 seconds (18.22 k allocations: 18.740 MiB)
Index     0.000177 seconds (44 allocations: 63.281 KiB)

d = 2048
CPU       0.012779 seconds (4.74 k allocations: 74.535 MiB, 25.15% gc time)
GPU       0.020421 seconds (37.87 k allocations: 70.653 MiB, 14.94% gc time)
Index     0.000683 seconds (71 allocations: 147.672 KiB)

d = 4096
CPU       0.040447 seconds (18.67 k allocations: 292.342 MiB, 12.00% gc time)
GPU       0.058996 seconds (82.66 k allocations: 263.911 MiB, 11.60% gc time)
Index     0.002649 seconds (143 allocations: 470.703 KiB)

d = 8192
CPU       0.155976 seconds (37.49 k allocations: 1.145 GiB, 13.94% gc time)
GPU       0.225138 seconds (165.99 k allocations: 1.008 GiB, 10.21% gc time)
Index     0.010904 seconds (268 allocations: 1.351 MiB)

d = 16384
CPU       0.685121 seconds (74.25 k allocations: 4.534 GiB, 13.60% gc time)
GPU       0.908984 seconds (328.80 k allocations: 3.938 GiB, 9.77% gc time)
Index     0.041428 seconds (501 allocations: 3.839 MiB)

d = 32768
Index     0.169528 seconds (1.03 k allocations: 15.046 MiB)

d = 65536
Index     0.698473 seconds (2.22 k allocations: 62.908 MiB, 0.27% gc time)

d = 131072
Index     2.817615 seconds (4.25 k allocations: 239.533 MiB, 0.18% gc time)
```
</details>